### PR TITLE
array_get() to Arr::get()

### DIFF
--- a/src/Support/HashidsFactory.php
+++ b/src/Support/HashidsFactory.php
@@ -13,6 +13,7 @@
 namespace Amamarul\Hashids\Support;
 
 use Amamarul\Hashids\Support\Hashids\Hashids;
+use Illuminate\Support\Arr;
 
 /**
  * This is the Hashids factory class.
@@ -47,10 +48,10 @@ class HashidsFactory
     protected function getConfig(array $config)
     {
         return [
-            'salt' => array_get($config, 'salt', ''),
-            'length' => array_get($config, 'length', 0),
-            'alphabet' => array_get($config, 'alphabet', ''),
-            'prefix' => array_get($config, 'prefix', null),
+            'salt' => Arr::get($config, 'salt', ''),
+            'length' => Arr::get($config, 'length', 0),
+            'alphabet' => Arr::get($config, 'alphabet', ''),
+            'prefix' => Arr::get($config, 'prefix', null),
         ];
     }
 


### PR DESCRIPTION
Laravel V10 not support array_get() to Arr::get()